### PR TITLE
Getting Started with Interfaces and Mocks

### DIFF
--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Entities/Die.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Entities/Die.cs
@@ -1,11 +1,12 @@
 ﻿using GettingStartedWithInterfacesAndMocks.DiceGame.Extensions;
+using GettingStartedWithInterfacesAndMocks.DiceGame.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace GettingStartedWithInterfacesAndMocks.DiceGame.Entities
 {
-    public class Die
+    public class Die : IDie
     {
         public Die()
         {

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Entities/Die.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Entities/Die.cs
@@ -1,0 +1,21 @@
+﻿using GettingStartedWithInterfacesAndMocks.DiceGame.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GettingStartedWithInterfacesAndMocks.DiceGame.Entities
+{
+    public class Die
+    {
+        public Die()
+        {
+            Roll();
+        }
+
+        public int Value { get; private set; }
+        public void Roll()
+        {
+            Value = DieRoller.GetD6Roll();
+        }
+    }
+}

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
@@ -14,6 +14,11 @@ namespace GettingStartedWithInterfacesAndMocks.DiceGame.Extensions
 
         public static bool IsFiveOfAKind(this IEnumerable<IDie> dice)
         {
+            if (!dice.IsValidRoll())
+            {
+                throw new ArgumentException("A valid roll must contain exactly five dice");
+            }
+
             throw new NotImplementedException();
         }
     }

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
@@ -9,7 +9,7 @@ namespace GettingStartedWithInterfacesAndMocks.DiceGame.Extensions
     {
         public static bool IsValidRoll(this IEnumerable<Die> dice)
         {
-            throw new NotImplementedException();
+            return dice.Count() == 5;
         }
     }
 }

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
@@ -1,4 +1,4 @@
-﻿using GettingStartedWithInterfacesAndMocks.DiceGame.Entities;
+﻿using GettingStartedWithInterfacesAndMocks.DiceGame.Interfaces;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -7,12 +7,12 @@ namespace GettingStartedWithInterfacesAndMocks.DiceGame.Extensions
 {
     public static class DieExtensions
     {
-        public static bool IsValidRoll(this IEnumerable<Die> dice)
+        public static bool IsValidRoll(this IEnumerable<IDie> dice)
         {
             return dice.Count() == 5;
         }
 
-        public static bool IsFiveOfAKind(this IEnumerable<Die> dice)
+        public static bool IsFiveOfAKind(this IEnumerable<IDie> dice)
         {
             throw new NotImplementedException();
         }

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GettingStartedWithInterfacesAndMocks.DiceGame.Extensions
+{
+    public static class DieExtensions
+    {
+
+    }
+}

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
@@ -1,11 +1,15 @@
-﻿using System;
+﻿using GettingStartedWithInterfacesAndMocks.DiceGame.Entities;
+using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace GettingStartedWithInterfacesAndMocks.DiceGame.Extensions
 {
     public static class DieExtensions
     {
-
+        public static bool IsValidRoll(this IEnumerable<Die> dice)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
@@ -11,5 +11,10 @@ namespace GettingStartedWithInterfacesAndMocks.DiceGame.Extensions
         {
             return dice.Count() == 5;
         }
+
+        public static bool IsFiveOfAKind(this IEnumerable<Die> dice)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieExtensions.cs
@@ -19,7 +19,7 @@ namespace GettingStartedWithInterfacesAndMocks.DiceGame.Extensions
                 throw new ArgumentException("A valid roll must contain exactly five dice");
             }
 
-            throw new NotImplementedException();
+            return dice.GroupBy(d => d.Value).Count() == 1;
         }
     }
 }

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieRoller.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieRoller.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿using GettingStartedWithInterfacesAndMocks.DiceGame.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace GettingStartedWithInterfacesAndMocks.DiceGame.Extensions
 {
@@ -11,5 +14,9 @@ namespace GettingStartedWithInterfacesAndMocks.DiceGame.Extensions
             return _rng.Next(1, 7);
         }
 
+        public static IEnumerable<Die> GetGameRoll()
+        {
+            return Enumerable.Range(1, 5).Select(_ => new Die());
+        }
     }
 }

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieRoller.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Extensions/DieRoller.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace GettingStartedWithInterfacesAndMocks.DiceGame.Extensions
+{
+    public static class DieRoller
+    {
+        static Random _rng = new Random();
+
+        public static int GetD6Roll()
+        {
+            return _rng.Next(1, 7);
+        }
+
+    }
+}

--- a/GettingStartedWithInterfacesAndMocks/DiceGame/Interfaces/IDie.cs
+++ b/GettingStartedWithInterfacesAndMocks/DiceGame/Interfaces/IDie.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace GettingStartedWithInterfacesAndMocks.DiceGame.Interfaces
+{
+    public interface IDie
+    {
+        void Roll();
+        int Value { get; }
+    }
+}

--- a/GettingStartedWithInterfacesAndMocks/GettingStartedWithInterfacesAndMocks.csproj
+++ b/GettingStartedWithInterfacesAndMocks/GettingStartedWithInterfacesAndMocks.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/GettingStartedWithInterfacesAndMocksTests/DieExtensionsTests.cs
+++ b/GettingStartedWithInterfacesAndMocksTests/DieExtensionsTests.cs
@@ -1,7 +1,9 @@
 ﻿using FluentAssertions;
 using GettingStartedWithInterfacesAndMocks.DiceGame.Entities;
 using GettingStartedWithInterfacesAndMocks.DiceGame.Extensions;
+using GettingStartedWithInterfacesAndMocksTests.TestingMocks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -29,13 +31,36 @@ namespace GettingStartedWithInterfacesAndMocksTests
         [TestMethod]
         public void IsFiveOfAKind_AllDiceAreTheSame_ReturnsTrue()
         {
-            IEnumerable<Die> dice = null; //Uh oh... how do I create dice that are all the same?
+            var dice = Enumerable.Range(1, 5).Select(_ => new SettableD6(5));
+
+            dice.IsFiveOfAKind().Should().BeTrue();
         }
 
         [TestMethod]
         public void IsFiveOfAKind_AllDiceAreNotTheSame_ReturnsFalse()
         {
+            var dice = new[]{
+                new SettableD6(1),
+                new SettableD6(3),
+                new SettableD6(4),
+                new SettableD6(1),
+                new SettableD6(1)
+            };
 
+            dice.IsFiveOfAKind().Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void IsFiveOfAKind_NotAValidRoll_ThrowsArgumentException()
+        {
+            var dice = new[]{
+                new SettableD6(2),
+                new SettableD6(3)
+            };
+
+            Action validateRoll = () => dice.IsFiveOfAKind();
+
+            validateRoll.Should().Throw<ArgumentException>();
         }
     }
 }

--- a/GettingStartedWithInterfacesAndMocksTests/DieExtensionsTests.cs
+++ b/GettingStartedWithInterfacesAndMocksTests/DieExtensionsTests.cs
@@ -2,7 +2,7 @@
 using GettingStartedWithInterfacesAndMocks.DiceGame.Entities;
 using GettingStartedWithInterfacesAndMocks.DiceGame.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace GettingStartedWithInterfacesAndMocksTests
@@ -24,6 +24,18 @@ namespace GettingStartedWithInterfacesAndMocksTests
             var dice = Enumerable.Range(1, 5).Select(_ => new Die());
 
             dice.IsValidRoll().Should().BeTrue(because: "A valid game roll has five dice");
+        }
+
+        [TestMethod]
+        public void IsFiveOfAKind_AllDiceAreTheSame_ReturnsTrue()
+        {
+            IEnumerable<Die> dice = null; //Uh oh... how do I create dice that are all the same?
+        }
+
+        [TestMethod]
+        public void IsFiveOfAKind_AllDiceAreNotTheSame_ReturnsFalse()
+        {
+
         }
     }
 }

--- a/GettingStartedWithInterfacesAndMocksTests/DieExtensionsTests.cs
+++ b/GettingStartedWithInterfacesAndMocksTests/DieExtensionsTests.cs
@@ -1,0 +1,29 @@
+﻿using FluentAssertions;
+using GettingStartedWithInterfacesAndMocks.DiceGame.Entities;
+using GettingStartedWithInterfacesAndMocks.DiceGame.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+
+namespace GettingStartedWithInterfacesAndMocksTests
+{
+    [TestClass]
+    public class DieExtensionsTests
+    {
+        [TestMethod]
+        public void IsValidRoll_RollHas4Dice_ReturnsFalse()
+        {
+            var dice = Enumerable.Range(1, 4).Select(_ => new Die());
+
+            dice.IsValidRoll().Should().BeFalse(because: "A valid game roll has five dice");
+        }
+
+        [TestMethod]
+        public void IsValidRoll_RollHas5Dice_ReturnsTrue()
+        {
+            var dice = Enumerable.Range(1, 5).Select(_ => new Die());
+
+            dice.IsValidRoll().Should().BeTrue(because: "A valid game roll has five dice");
+        }
+    }
+}

--- a/GettingStartedWithInterfacesAndMocksTests/GettingStartedWithInterfacesAndMocksTests.csproj
+++ b/GettingStartedWithInterfacesAndMocksTests/GettingStartedWithInterfacesAndMocksTests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/GettingStartedWithInterfacesAndMocksTests/GettingStartedWithInterfacesAndMocksTests.csproj
+++ b/GettingStartedWithInterfacesAndMocksTests/GettingStartedWithInterfacesAndMocksTests.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\GettingStartedWithInterfacesAndMocks\GettingStartedWithInterfacesAndMocks.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/GettingStartedWithInterfacesAndMocksTests/TestingMocks/SettableD6.cs
+++ b/GettingStartedWithInterfacesAndMocksTests/TestingMocks/SettableD6.cs
@@ -1,0 +1,22 @@
+﻿using GettingStartedWithInterfacesAndMocks.DiceGame.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GettingStartedWithInterfacesAndMocksTests.TestingMocks
+{
+    public class SettableD6 : IDie
+    {
+        public SettableD6(int value)
+        {
+            Value = value;
+        }
+
+        public int Value { get; set; }
+
+        public void Roll()
+        {
+            //Does nothing
+        }
+    }
+}

--- a/TestingPracticesWithExamples.sln
+++ b/TestingPracticesWithExamples.sln
@@ -3,7 +3,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29609.76
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GettingStarted", "GettingStarted\GettingStarted.csproj", "{AAB66502-A5F2-40D8-BCB4-F7EDB0923640}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "InterfacesAndMocks", "InterfacesAndMocks", "{42786B9F-B4BA-4D56-8104-D359C5E0E917}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GettingStartedWithInterfacesAndMocks", "GettingStartedWithInterfacesAndMocks\GettingStartedWithInterfacesAndMocks.csproj", "{22E941F6-26EC-47CE-84A7-0456BF6EF2A1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GettingStartedWithInterfacesAndMocksTests", "GettingStartedWithInterfacesAndMocksTests\GettingStartedWithInterfacesAndMocksTests.csproj", "{7BE9A85F-1902-4448-8023-9DC5EF821EE7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,13 +15,21 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{AAB66502-A5F2-40D8-BCB4-F7EDB0923640}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AAB66502-A5F2-40D8-BCB4-F7EDB0923640}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AAB66502-A5F2-40D8-BCB4-F7EDB0923640}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AAB66502-A5F2-40D8-BCB4-F7EDB0923640}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22E941F6-26EC-47CE-84A7-0456BF6EF2A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22E941F6-26EC-47CE-84A7-0456BF6EF2A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22E941F6-26EC-47CE-84A7-0456BF6EF2A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22E941F6-26EC-47CE-84A7-0456BF6EF2A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BE9A85F-1902-4448-8023-9DC5EF821EE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BE9A85F-1902-4448-8023-9DC5EF821EE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BE9A85F-1902-4448-8023-9DC5EF821EE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BE9A85F-1902-4448-8023-9DC5EF821EE7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{22E941F6-26EC-47CE-84A7-0456BF6EF2A1} = {42786B9F-B4BA-4D56-8104-D359C5E0E917}
+		{7BE9A85F-1902-4448-8023-9DC5EF821EE7} = {42786B9F-B4BA-4D56-8104-D359C5E0E917}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {BA44BE1E-A335-4CCF-9ACF-D80E199328B3}


### PR DESCRIPTION
In this section, we'll have a basic discussion about using interfaces and mocks for testing.

The use of interfaces is a much larger conversation that applies to much more than simply testing. Prudent use of interfaces helps us create systems with much less coupling between components. This allows us to modify, maintain and test components much more easily.

Mocks, specifically, help with testing to allow us to independently test components that have dependencies without having the tests themselves require the dependencies. Dependencies can often be difficult to set up the way we want, or don't allow us to have complete control of the data we receive. Mocks can also help us when we're testing other things that we can't control like time or randomness.

Let's look at some concrete examples.